### PR TITLE
feat: support more target framworks

### DIFF
--- a/EF-Adapter.UnitTest/EF-Adapter.UnitTest.csproj
+++ b/EF-Adapter.UnitTest/EF-Adapter.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net452;net461;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>EF_Adapter.UnitTest</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/EF-Adapter/EF-Adapter.csproj
+++ b/EF-Adapter/EF-Adapter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>net45;net461;netstandard2.1</TargetFrameworks>
     <RootNamespace>Casbin.NET.Adapter.EF</RootNamespace>
     <PackageId>Casbin.NET.Adapter.EF</PackageId>
     <Version>1.2.1</Version>


### PR DESCRIPTION
EF-Adapter target frameworks
<TargetFrameworks>net45;net461;netstandard2.1</TargetFrameworks>

EF-Adapter.UnitTest target frameworks
<TargetFrameworks>net452;net461;netcoreapp3.1</TargetFrameworks>

[Request for this change](https://github.com/casbin-net/EF-Adapter/pull/2#issuecomment-771339726)